### PR TITLE
カテゴリー機能

### DIFF
--- a/app/assets/javascripts/product.js
+++ b/app/assets/javascripts/product.js
@@ -59,9 +59,10 @@ $(document).on('turbolinks:load', ()=> {
 });
 
 //動的カテゴリボックスの実装
-
+$(document).on('turbolinks:load', ()=> {
 $('#parent-form').on('change', function(){
   let parentValue = document.getElementById("parent-form").value;
+  
   if (parentValue != "選択してください"){
   $.ajax({
     url: '/products/search',
@@ -138,7 +139,7 @@ $(document).on('change','#child-form', function(){
     $('#grandchild-form').remove();
   }
 });
-
+})
 })
 
 

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -6,7 +6,7 @@ class ProductsController < ApplicationController
 
 
   before_action :set_category, only: [:new]
-  before_action :set_product, except: [:index, :new, :create]
+  before_action :set_product, only: [:show,:edit,:destroy,:update]
 
 
   def index


### PR DESCRIPTION
##what
productコントローラーのbefore_action :set_productをbefore_action :set_product, only: [:show,:edit,:destroy,:update]に変更しました。

product.jsのカテゴリーの記述をターボリンクスロードで囲いました。

##why
出品ページ遷移時にリロードなしで動作させるため