### PR TITLE
出品ページの画像ボタンが押せなくなる件の修正

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -24,8 +24,10 @@ class ProductsController < ApplicationController
     if @product.save
       redirect_to user_path(current_user.id)
     else
-      render :new
-    end
+      
+      render :new,locals: {product: new}
+      end
+    
 
   end
 

--- a/app/views/products/_form.html.haml
+++ b/app/views/products/_form.html.haml
@@ -8,7 +8,7 @@
 
 
     .js-file_group{"data-index" => "#{f.index}"}
-      = f.file_field :src, class: 'js-file'
+      = f.file_field :src, class: 'js-file',required:true
       %span.js-remove 削除
     - if @product.persisted?
       = image.check_box :_destroy, data:{ index: image.index }, class: 'hidden-destroy'

--- a/app/views/products/new.html.haml
+++ b/app/views/products/new.html.haml
@@ -13,21 +13,20 @@
           %p最大10枚までアップロードできます
           = f.fields_for :images do |image|      
             = render 'form', f: image
-
-            
+          
       .exhibit__all__name
         .left_text
           %span.fat 商品名 
           %span.red 必須
         .form
-          = f.text_field :name, placeholder:"40字まで" , class:"name_form"
+          = f.text_field :name, placeholder:"40字まで" , class:"name_form",required:true
 
       .exhibit__all__details
         .left_text
           %span.fat 商品の説明
           %span.red 必須
         .form
-        = f.text_area :details,placeholder:"傷が少しあります" , class:"name_form"
+        = f.text_area :details,placeholder:"傷が少しあります" , class:"name_form",required:true
 
       .exhibit__all__example
         .example_name
@@ -37,14 +36,14 @@
             %span.fat カテゴリー
             %span.red 必須
           .form{id: 'formId'}
-            = f.collection_select :category_id, Category.all.where(ancestry: nil).limit(13), :id, :name,{prompt: "選択してください"}, name: '',id: "parent-form",selected:true
+            = f.collection_select :category_id, Category.all.where(ancestry: nil).limit(13), :id, :name,{prompt: "選択してください"}, name: '',id: "parent-form",selected:true,required:true
           
         .exhibit__all__example__condtion
           .left_text
             %span.fat 商品の状態
             %span.red 必須
           .form  
-            = f.select :condition, [ ["新品","新品"], ["未使用に近い","未使用に近い"], ["やや傷あり", "やや傷あり" ] ,["全体的に傷あり", "全体的に傷あり"]], prompt: "選択してください"
+            = f.select :condition, [ ["新品","新品"], ["未使用に近い","未使用に近い"], ["やや傷あり", "やや傷あり" ] ,["全体的に傷あり", "全体的に傷あり"]], prompt: "選択してください",required:true
 
       .exhibit__all__send
         .send_name
@@ -54,21 +53,21 @@
             %span.fat 配送料の負担
             %span.red 必須
           .form  
-            = f.select :exhibition, [ ["送料込み（出品者負担）","送料込み（出品者負担）"], ["着払い（購入者負担）", "着払い（購入者負担）"]], prompt: "選択してください"
+            = f.select :exhibition, [ ["送料込み（出品者負担）","送料込み（出品者負担）"], ["着払い（購入者負担）", "着払い（購入者負担）"]], prompt: "選択してください",required:true
 
         .exhibit__all__send__area
           .left_text
             %span.fat 発送元の地域
             %span.red 必須
           .form  
-            = f.collection_select :prefecture_id, Prefecture.all, :id, :name, prompt: "選択してください"
+            = f.collection_select :prefecture_id, Prefecture.all, :id, :name, prompt: "選択してください",required:true
 
         .exhibit__all__send__date
           .left_text
             %span.fat 発送までの日数
             %span.red 必須
           .form  
-            = f.select :shippingdate, [ ["１〜２日","１〜２日"], ["３〜４日い", "３〜４日い"], ["４日以上", "４日以上" ] ], prompt: "選択してください"
+            = f.select :shippingdate, [ ["１〜２日","１〜２日"], ["３〜４日い", "３〜４日い"], ["４日以上", "４日以上" ] ], prompt: "選択してください",required:true
 
       .exhibit__all__price
         %p価格（¥300〜9,999,999）
@@ -78,7 +77,7 @@
             %span.red 必須
           .form      
             %span.red ¥
-            = f.number_field :price, class:"name_form"
+            = f.number_field :price, class:"name_form",required:true
         .fee    
           %p#tax 販売手数料（10%）
           %p#tax -


### PR DESCRIPTION
##出品のインプットタグに全て,required:trueを付けて空欄があればそもそも出品できない状態にした。
仮に何らかの方法で空欄で投稿できたとしてもサイド出品ページに戻ってくるようにしたので画像選択ボタンが消えることはなくなった

#エラー修正のため